### PR TITLE
Fix: Dynamically translate validation messages to respect current locale

### DIFF
--- a/src/EmailVerifyServiceProvider.php
+++ b/src/EmailVerifyServiceProvider.php
@@ -73,8 +73,19 @@ class EmailVerifyServiceProvider extends ServiceProvider
                 $indisposable = new Indisposable($cache ?? null);
 
                 return $indisposable->validate($attribute, $value, $parameters, $validator);
+            });
 
-            }, $translator->get(static::$abstract . '::validation.email_verify'));
+            // Add a replacer that gets the translation message at runtime
+            $validator->replacer('email_verify', function ($message, $attribute, $rule, $parameters) use ($app) {
+                $translatedMessage = $app['translator']->get(static::$abstract.'::validation.email_verify');
+
+                // Get the custom attribute name if defined in validation.php attributes array
+                $customAttributes = $app['translator']->get('validation.attributes');
+                $attributeName = $customAttributes[$attribute] ?? $attribute;
+
+                // Replace the attribute placeholder with the translated attribute name
+                return str_replace(':attribute', $attributeName, $translatedMessage);
+            });
         });
     }
 


### PR DESCRIPTION
The validation error messages for the `email_verify` rule were being resolved at application boot time, which meant they always used the default locale from `config/app.php`. This prevented the messages from being properly translated when using middleware or other mechanisms to set the locale based on user preferences or request parameters